### PR TITLE
Add parent transforms for unary Children

### DIFF
--- a/python/aunt-kg.py
+++ b/python/aunt-kg.py
@@ -18,17 +18,17 @@ def preprocessing(server, datasets=DATASETS):
                     downloaded = src.download("(Individuals $i (Fullname $name))", "$name")
                     print("names", dataset, downloaded.data)
 
-                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Fullname $name)))"), ("(simple (hasName $id $name))", "(simple (hasId $name $id))"))
+                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Fullname $name)))"), ("(simple (hasName $id $name))", "(simple (hasId $name $id))")).block()
 
-                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Sex \"M\")))"), ("(simple (male $id))",))
-                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Sex \"F\")))"), ("(simple (female $id))",))
+                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Sex \"M\")))"), ("(simple (male $id))",)).block()
+                scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Sex \"F\")))"), ("(simple (female $id))",)).block()
 
                 scope.transform(("(src (Relations $r (Husband $id)))", "(src (Relations $r (Children $lci $cid)))"), ("(simple (parent $id $cid))",))\
                     .block()
-                scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $lci $cid)))"), ("(simple (parent $id $cid))",))
+                scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $lci $cid)))"), ("(simple (parent $id $cid))",)).block()
                 scope.transform(("(src (Relations $r (Husband $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",))\
                     .block()
-                scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",))
+                scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",)).block()
 
     ins.sexpr_export("($dataset (simple $x))", "($dataset $x)", "file://" + __file__.rpartition("/")[0] + "/simple_all.metta")
 

--- a/python/aunt-kg.py
+++ b/python/aunt-kg.py
@@ -18,6 +18,19 @@ def preprocessing(server, datasets=DATASETS):
                     downloaded = src.download("(Individuals $i (Fullname $name))", "$name")
                     print("names", dataset, downloaded.data)
 
+                # Generate isIdDifferent relations so that sister relations aren't reflective
+                ids_string = scope.download("(src (Individuals $i (Id $id)))", "$id").data
+                ids = [line.strip()[1:-1] for line in ids_string.strip().splitlines() if line.strip()]
+
+                entries = []
+                for id0 in ids:
+                    for id1 in ids:
+                        if id0 != id1:
+                            entry = f'(simple (isIdDifferent "{id0}" "{id1}"))'
+                            entries.append(entry)
+                to_upload = "\n".join(entries)
+                scope.upload_(to_upload)
+
                 scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Fullname $name)))"), ("(simple (hasName $id $name))", "(simple (hasId $name $id))")).block()
 
                 scope.transform(("(src (Individuals $i (Id $id)))", "(src (Individuals $i (Sex \"M\")))"), ("(simple (male $id))",)).block()
@@ -29,6 +42,16 @@ def preprocessing(server, datasets=DATASETS):
                 scope.transform(("(src (Relations $r (Husband $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",))\
                     .block()
                 scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",)).block()
+
+                scope.transform(("(simple (parent $pid $cid))", "(simple (female $pid))",), ("(simple (mother $pid $cid))",),).block()
+                scope.transform(("(simple (mother $pid $cid))", "(simple (hasName $pid $name0))", "(simple (hasName $cid $name1))",), ("(simple (motherByName $name0 $name1))",),).block()
+
+                scope.transform(("(simple (parent $pid $cid0))", "(simple (parent $pid $cid1))", "(simple (isIdDifferent $cid0 $cid1))", "(simple (female $cid0))",), ("(simple (sister $cid0 $cid1))",),).block()
+                scope.transform(("(simple (sister $cid0 $cid1))", "(simple (hasName $cid0 $name0))", "(simple (hasName $cid1 $name1))",), ("(simple (sisterByName $name0 $name1))",),).block()
+
+                scope.transform(("(simple (parent $pid $cid))", "(simple (sister $aid $pid))",), ("(simple (aunt $aid $cid))",),).block()
+                scope.transform(("(simple (aunt $aid $cid))", "(simple (hasName $aid $name0))", "(simple (hasName $cid $name1))",), ("(simple (auntByName $name0 $name1))",),).block()
+
 
     ins.sexpr_export("($dataset (simple $x))", "($dataset $x)", "file://" + __file__.rpartition("/")[0] + "/simple_all.metta")
 

--- a/python/aunt-kg.py
+++ b/python/aunt-kg.py
@@ -16,7 +16,7 @@ def preprocessing(server, datasets=DATASETS):
                     src.sexpr_import_(f"https://raw.githubusercontent.com/Adam-Vandervorst/metta-examples/refs/heads/main/aunt-kg/{dataset}.metta")\
                         .block()
                     downloaded = src.download("(Individuals $i (Fullname $name))", "$name")
-                    print("names", dataset, downloaded.data)
+                    # print("names", dataset, downloaded.data)
 
                 # Generate isIdDifferent relations so that sister relations aren't reflective
                 ids_string = scope.download("(src (Individuals $i (Id $id)))", "$id").data
@@ -55,8 +55,8 @@ def preprocessing(server, datasets=DATASETS):
 
     ins.sexpr_export("($dataset (simple $x))", "($dataset $x)", "file://" + __file__.rpartition("/")[0] + "/simple_all.metta")
 
-    for i, item in enumerate(ins.history):
-        print("preprocessing event", i, str(item))
+    # for i, item in enumerate(ins.history):
+    #     print("preprocessing event", i, str(item))
 
 def _main():
     with ManagedMORK.connect(binary_path="../target/release/mork_server").and_terminate() as server:

--- a/python/aunt-kg.py
+++ b/python/aunt-kg.py
@@ -26,6 +26,9 @@ def preprocessing(server, datasets=DATASETS):
                 scope.transform(("(src (Relations $r (Husband $id)))", "(src (Relations $r (Children $lci $cid)))"), ("(simple (parent $id $cid))",))\
                     .block()
                 scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $lci $cid)))"), ("(simple (parent $id $cid))",))
+                scope.transform(("(src (Relations $r (Husband $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",))\
+                    .block()
+                scope.transform(("(src (Relations $r (Wife $id)))", "(src (Relations $r (Children $cid)))"), ("(simple (parent $id $cid))",))
 
     ins.sexpr_export("($dataset (simple $x))", "($dataset $x)", "file://" + __file__.rpartition("/")[0] + "/simple_all.metta")
 


### PR DESCRIPTION
Create `parent` sexps for cases where `Children` is unary and doesn't have an index entry, e.g. Relations 0 as opposed to Relations 1 in [lordOfTheRings.metta](https://github.com/Adam-Vandervorst/metta-examples/blob/2e00d8990409ca6519325f5009d4918e1426c314/aunt-kg/lordOfTheRings.metta#L1978C1-L1989C37):

```
(Relations 0 (Id "@F0001@"))
(Relations 0 (Husband "@I0006@"))
(Relations 0 (Wife "@I0022@"))
(Relations 0 (Children "@I0002@"))
(Relations 1 (Id "@F0002@"))
(Relations 1 (Husband "@I0007@"))
(Relations 1 (Wife "@I0026@"))
(Relations 1 (Children 0 "@I0006@"))
(Relations 1 (Children 1 "@I0018@"))
(Relations 1 (Children 2 "@I0019@"))
(Relations 1 (Children 3 "@I0020@"))
(Relations 1 (Children 4 "@I0021@"))
```