### PR TITLE
Add Server-Sent Events (SSE) Support for Status Updates

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -433,7 +433,7 @@ class MORK:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if "time" in self.finalization: print(f"{self.ns.format("*")} time {monotonic() - self.t0:.6f} s")
-        if "clear" in self.finalization: self.clear().block()
+        if "clear" in self.finalization: self.clear().listen()
         if "spin_down" in self.finalization: self.spin_down()
         if "stop" in self.finalization: self.stop()
 
@@ -595,7 +595,7 @@ def _main():
 
             print("data", ins.download_().data)
 
-            ins.sexpr_import_("https://raw.githubusercontent.com/trueagi-io/metta-examples/refs/heads/main/aunt-kg/simpsons.metta").block()
+            ins.sexpr_import_("https://raw.githubusercontent.com/trueagi-io/metta-examples/refs/heads/main/aunt-kg/simpsons.metta").listen()
 
             print("data", ins.download_().data)
 
@@ -607,8 +607,8 @@ def _main_mm2():
     # smoke test
     with ManagedMORK.connect("../target/debug/mork_server").and_log_stdout().and_log_stderr().and_terminate() as server:
         server.upload_("(data (foo 1))\n(data (foo 2))\n(_exec 0 (, (data (foo $x))) (, (data (bar $x))))")
-        server.transform(("(_exec $priority $p $t)",), ("(exec (test $priority) $p $t)",)).block()
-        server.exec(thread_id="test").block()
+        server.transform(("(_exec $priority $p $t)",), ("(exec (test $priority) $p $t)",)).listen()
+        server.exec(thread_id="test").listen()
         print("data", server.download_().data)
 
         for i, item in enumerate(server.history):
@@ -624,8 +624,8 @@ def test_sse_status():
 
 if __name__ == '__main__':
     # _main()
-    # _main_mm2()
-    test_sse_status()
+    _main_mm2()
+    # test_sse_status()
 
 
 

--- a/python/client.py
+++ b/python/client.py
@@ -92,7 +92,7 @@ class MORK:
             Listens to server side events on the status of a request.
             """
 
-            url = self.server.base + f"/status_sse/{quote(self.status_loc)}"
+            url = self.server.base + f"/status_stream/{quote(self.status_loc)}"
 
             def on_error():
                 raise Exception("error")
@@ -615,8 +615,6 @@ def _main_mm2():
             print(i, str(item))
 
 def test_sse_status():
-    # response = requests.get("http://localhost:8000/status_sse/", stream=True)
-
     with ManagedMORK.connect("../target/debug/mork_server").and_log_stdout().and_log_stderr().and_terminate() as server:
         server.sexpr_import_(f"https://raw.githubusercontent.com/Adam-Vandervorst/metta-examples/refs/heads/main/aunt-kg/simpsons.metta").listen()
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2025.6.15
+charset-normalizer==3.4.2
+idna==3.10
+requests==2.32.4
+requests-sse==0.5.2
+urllib3==2.5.0

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,8 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 scc = { version = "2.3.0", optional = true }
 num_cpus = { version = "1.16.0", optional = true }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
+futures-util = { version="0.3.30" }
 
 [dev-dependencies]
 

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -1114,10 +1114,10 @@ impl CommandDefinition for StatusCmd {
     }
 }
 
-pub struct StatusSseCmd;
+pub struct StatusStreamCmd;
 
-impl CommandDefinition for StatusSseCmd {
-    const NAME: &'static str = "status_sse";
+impl CommandDefinition for StatusStreamCmd {
+    const NAME: &'static str = "status_stream";
     const CONST_CMD: &'static Self = &Self;
     const CONSUME_WORKER: bool = false;
 
@@ -1138,12 +1138,6 @@ impl CommandDefinition for StatusSseCmd {
         cmd: Command,
         _thread: Option<WorkThreadHandle>, _req: Request<IncomingBody>
     ) -> Result<WorkResult, CommandError> {
-
-        let response_builder = Response::builder()
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "GET, OPTIONS")
-            .header("Access-Control-Allow-Headers", "Content-Type");
-
 
         let (tx, rx) = mpsc::channel::<StatusRecord>(100);
 

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -1159,7 +1159,6 @@ impl CommandDefinition for StatusSseCmd {
                 println!("Checking status update!!!");
 
                 if tx.is_closed() {
-                    println!("tx is closed");
                     break;
                 }
 
@@ -1168,13 +1167,11 @@ impl CommandDefinition for StatusSseCmd {
                         match tx.send(StatusRecord::PathClear).await {
                             Ok(_) => {
                                 println!("Path cleared!!!");  
-                                let _ = tx.send(StatusRecord::PathClear).await;
                             },
                             Err(e) => {
                                 println!("Failed to send status update: {}", e);
                             }
                         };
-
                         break;
                     },
                     _ => {
@@ -1185,23 +1182,12 @@ impl CommandDefinition for StatusSseCmd {
             }
         });
 
-        // Map<ReceiverStream<StatusRecord>, FnMut<StatusRecord> -> Result<Frame<Bytes>, hyper::Error>>
         let stream = ReceiverStream::new(rx).map(|quote| {
             let data = serde_json::to_string(&quote).unwrap();
             let event = format!("data: {}\n\n", data);
             Ok(Frame::data(Bytes::from(event)))
         });
 
-        //let response = response_builder
-        //    .status(StatusCode::OK)
-        //    .header("Content-Type", "text/event-stream")
-        //    .header("Cache-Control", "no-cache")
-        //    .header("Connection", "keep-alive")
-        //    .body(StreamBody::new(Box::pin(stream)
-        //        as Pin<
-        //            Box<dyn Stream<Item = Result<Frame<Bytes>, Infallible>> + Send + Sync>,
-        //        >))
-        //    .unwrap();
         Ok(WorkResult::Streamed(Box::pin(stream)))
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -179,7 +179,7 @@ impl MorkService {
             println!("Processing: cmd={}, args={:?}", command.def.name(), command.args); //GOAT Log this
             let mut response = match command.def.work(ctx.clone(), command.clone(), work_thread, req).await {
                 Ok(response_bytes) => {
-                    ok_response(response_bytes)
+                    ok_response(response_bytes.get_bytes().unwrap_or("".into()))
                 },
                 Err(err) => {
                     let response = MorkServerError::cmd_err(err, &command).error_response();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -545,6 +545,7 @@ impl Service<Request<IncomingBody>> for MorkService {
             | GET => ExportCmd
             | GET => ImportCmd
             | GET => StatusCmd
+            | GET => StatusSseCmd
             | GET => StopCmd
             | POST => UploadCmd
             // neo4j

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -572,7 +572,7 @@ impl Service<Request<IncomingBody>> for MorkService {
             | GET => ExportCmd
             | GET => ImportCmd
             | GET => StatusCmd
-            | GET => StatusSseCmd
+            | GET => StatusStreamCmd
             | GET => StopCmd
             | POST => UploadCmd
             // neo4j


### PR DESCRIPTION


## Overview

This PR introduces an additional Server-Sent Events (SSE) endpoint to provide real-time status updates from the MORK server to clients. The main changes include:

## Key Changes

1) SSE Endpoint Added
    - New `/status_stream/{expr}` endpoint that streams status updates
    - Uses `requests-sse` Python client library for event consumption
    - Implements proper SSE protocol with `text/event-stream` content type

2) Streaming Response Infrastructure
    - Added `WorkResult` enum to support both immediate and streamed responses
    - Implemented `BoxStream` type for streaming HTTP responses
    - Added proper SSE headers and connection handling

3) Client-Side Changes
    - New `listen()` method in Python client for SSE consumption
    - Added requirements.txt with `requests` and `requests-sse` added

4) Server Improvements
    - Status monitoring now uses async channels for event delivery
    - Proper connection handling and error management
    - Periodic status checks with configurable intervals

5) Example Usage
    ```python
    with ManagedMORK.connect() as server:
        server.sexpr_import_(url).listen()  # Uses SSE instead of polling
    ```

## Benefits

- Eliminates polling overhead for status checks
- Provides real-time updates to clients
- More efficient resource utilization
- Better user experience with immediate feedback

## Technical Details

- Uses tokio's mpsc channels for event delivery
- Implements proper SSE framing with `data:` prefix
- Maintains backward compatibility with existing status endpoint
- Includes proper error handling and connection management

The changes maintain all existing functionality while adding the new SSE capability as an optional enhancement.

