### PR TITLE
Coro paths

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,9 @@
 
 [build]
-#rustflags = "-C opt-level=3 -C target-cpu=native -C lto=fat -C embed-bitcode=yes -Z dylib-lto"
+rustflags = "-C opt-level=3 -C target-cpu=native -C lto=fat -C embed-bitcode=yes -Z dylib-lto"
 
 # "opt-level=3" removes debug asserts
-rustflags = ["--emit", "asm", "-C", "target-cpu=native", "-Awarnings"]
+#rustflags = ["--emit", "asm", "-C", "target-cpu=native", "-Awarnings"]
 
 # this allows tests to reference files datasets from the workspace root instead of being forced to work backwards
 [env]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mork"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # [build]
 # rustflags = "-C opt-level=3 -C target-cpu=native"
@@ -19,6 +19,7 @@ memmap2 = "0.9.5"
 #tokio = "1.43.0"
 uuid = { version = "1.14.0" , features = ["v4", "fast-rng"] }
 futures = "0.3.31"
+async-stream = "0.3.6"
 freeze = { workspace = true }
 neo4rs = { version = "0.9.0-rc.6", optional = true }
 tokio = { version = "1.44.0", optional = true }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -29,3 +29,4 @@ rand = "0.9.1"
 default = []
 neo4j = ["dep:neo4rs", "dep:tokio"]
 interning = []
+nightly = ["pathmap/nightly"]

--- a/kernel/src/json_parser.rs
+++ b/kernel/src/json_parser.rs
@@ -871,7 +871,7 @@ impl<'a> Parser<'a> {
     }
 
     pub (crate) fn aparse<S, T : ATranscriber<S>>(&mut self, t: &mut T) -> impl std::ops::Coroutine<(), Yield=S, Return=Result<()>> {
-        let coro = #[coroutine] move || {
+        #[coroutine] move || {
         let mut stack = Vec::with_capacity(3);
         let mut ch = expect_byte_ignore_whitespace!(self);
         t.begin();
@@ -1021,8 +1021,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-    };
-    coro
+    }
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,3 +1,8 @@
+#![feature(gen_blocks)]
+#![feature(coroutine_trait)]
+#![feature(coroutines)]
+#![feature(stmt_expr_attributes)]
+
 pub mod space;
 mod json_parser;
 pub mod prefix;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1072,6 +1072,7 @@ fn bench_clique_no_unify(nnodes: usize, nedges: usize, max_clique: usize) {
     // found 0 6-cliques (expected 1) in 1288009964 µs
 }
 
+#[cfg(all(feature = "nightly"))]
 fn json_upaths_smoke() {
     let test = r#"{
 "first_name": "John",
@@ -1120,6 +1121,7 @@ fn json_upaths_smoke() {
 "#);
 }
 
+#[cfg(all(feature = "nightly"))]
 fn json_upaths<IPath: AsRef<std::path::Path>, OPath : AsRef<std::path::Path>>(json_path: IPath, upaths_path: OPath) {
     println!("mmapping JSON file {:?}", json_path.as_ref().as_os_str());
     println!("writing out unordered .paths file {:?}", upaths_path.as_ref().as_os_str());
@@ -1132,6 +1134,11 @@ fn json_upaths<IPath: AsRef<std::path::Path>, OPath : AsRef<std::path::Path>>(js
     let t0 = Instant::now();
     let written = s.json_to_paths(&*json_mmap, &mut upaths_bufwriter).unwrap();
     println!("written {written} in {} ms", t0.elapsed().as_millis());
+    // (zephy)
+    // mmapping JSON file "/home/adam/Downloads/G37S-9NQ.json"
+    // writing out unordered .paths file "G37S-9NQ.upaths"
+    // Ok(SerializationStats { bytes_out: 1415053, bytes_in: 12346358, path_count: 224769 })
+    // written 224769 in 193 ms
 }
 
 fn main() {
@@ -1166,8 +1173,12 @@ fn main() {
     // bench_transitive_no_unify(50000, 1000000);
     // bench_clique_no_unify(200, 3600, 5);
 
-    let mut args: Vec<_> = std::env::args().collect();
-    json_upaths(args[1].as_str(), args[2].as_str());
+    #[cfg(all(feature = "nightly"))]
+    json_upaths_smoke();
+    // let mut args: Vec<_> = std::env::args().collect();
+    // json_upaths(args[1].as_str(), args[2].as_str());
+    #[cfg(all(feature = "nightly"))]
+    json_upaths("/home/adam/Downloads/G37S-9NQ.json", "G37S-9NQ.upaths");
     return;
 
     let mut s = Space::new();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1072,6 +1072,35 @@ fn bench_clique_no_unify(nnodes: usize, nedges: usize, max_clique: usize) {
     // found 0 6-cliques (expected 1) in 1288009964 µs
 }
 
+fn json_upaths(src: &str, dst: &str) {
+    let everythingfs = r#"{
+"first_name": "John",
+"last_name": "Smith",
+"is_alive": true,
+"age": 27,
+"address": {
+  "street_address": "21 2nd Street",
+  "city": "New York",
+  "state": "NY",
+  "postal_code": "10021-3100"},
+"phone_numbers": [
+  {"type": "home", "number": "212 555-1234"},
+  {"type": "office", "number": "646 555-4567"}],
+"children": ["Catherine", "Thomas", "Trevor"],
+"spouse": null}"#;
+    let mut cv = vec![];
+
+    let mut s = Space::new();
+    let written = s.json_to_paths(everythingfs.as_bytes(), &mut cv).unwrap();
+    println!("written {written}");
+    // pathmap::path_serialization::deserialize_paths_(s.btm.write_zipper(), &cv[..], ()).unwrap();
+
+    // let mut v = vec![];
+    // s.dump_all_sexpr(&mut v).unwrap();
+    // let res = String::from_utf8(v).unwrap();
+    // println!("res {res}");
+}
+
 fn main() {
     env_logger::init();
 
@@ -1102,8 +1131,9 @@ fn main() {
     // match_case();
 
     // bench_transitive_no_unify(50000, 1000000);
-    bench_clique_no_unify(200, 3600, 6);
+    // bench_clique_no_unify(200, 3600, 5);
 
+    json_upaths("", "");
     return;
 
     let mut s = Space::new();


### PR DESCRIPTION
This makes two changes additional to the JSON-to-upaths conversion:
Re-enable opt-level=3 (13% performance on large benchmarks is impossible to ignore).
Require nightly for building MORK.