### PR TITLE
add subtract command

### DIFF
--- a/kernel/src/space.rs
+++ b/kernel/src/space.rs
@@ -2044,6 +2044,70 @@ pub(crate) fn transform_multi_multi_impl<'s, E, RZ, WZ> (
         (touched, any_new)
 }
 
+pub(crate) fn subtract_multi_multi_impl<'s, E, RZ, WZ> (
+    patterns            : &[E],
+    pattern_rzs         : &[RZ],
+    templates           : &[E],
+    template_prefixes   : &[(usize, usize)],
+    template_wzs        : &mut [WZ],
+) -> (usize, bool)
+    where
+    E: ExprTrait,
+    RZ : ZipperMoving + ZipperReadOnlySubtries<'s, ()> + ZipperInfallibleSubtries<()> + ZipperAbsolutePath,
+    WZ : ZipperMoving + ZipperWriting<()>
+{
+        let mut buffer = Vec::with_capacity(1 << 32);
+
+        let mut any_new = false;
+        let touched = query_multi_impl(patterns, pattern_rzs, |refs_bindings, loc| {
+
+            let Err((ref bindings, mut oi, mut ni, mut assignments)) = refs_bindings else { todo!() };
+            #[cfg(debug_assertions)]
+            bindings.iter().for_each(|(v, ee)| trace!(target: "subtract", "binding {:?} {}", *v, ee.show()));
+
+            for (i, ((incremental_path_start, wz_idx), template)) in template_prefixes.iter().zip(templates.iter()).enumerate() {
+                let wz = &mut template_wzs[*wz_idx];
+
+                let mut oz = ExprZipper::new(Expr { ptr: buffer.as_mut_ptr() });
+
+                trace!(target: "subtract", "{i} template {} @ ({oi} {ni})", serialize(unsafe { template.borrow().span().as_ref().unwrap()}));
+                // println!("ass len {}", assignments.len());
+                let mut ass = if i == 0 {
+                    // assignments.clone()
+                    vec![]
+                } else {
+                    // assignments[..1].to_vec()
+                    vec![]
+                };
+                // let mut ass = vec![];
+                let res = mork_bytestring::apply(0 as u8, 0 as u8, 0, &mut ExprZipper::new(template.borrow()), bindings, &mut oz, &mut BTreeMap::new(), &mut vec![], &mut ass);
+                // println!("res {:?}", res);
+                // (oi, ni) = res;
+
+                //   0      1      2      3      4      5      6      7      8      9
+                //  [(1,3), (3,4), (3,5), (3,6), (3,0), (3,1), (3,7), (3,8), (3,2), (3,3)]
+                // <0, 3> = (, (petri (? <3,4> <3,5> <3,6>)) (petri (! <3,0> <3,1>)) (exec PC0 <3,7> <3,8>))
+                // <0, 4> = (, (petri <3,2>) (exec PC0 <3,3> <3,4>))
+                // [4] exec PC0 _4 _5
+
+                // loc.transformed(template,)
+                trace!(target: "subtract", "{i} out {:?}", oz.root);
+                // println!("descending {:?} to {:?}", serialize(prefix), serialize(&buffer[template_prefixes[subsumption[i]].len()..oz.loc]));
+
+                wz.descend_to(unsafe { &slice_from_raw_parts(buffer.as_ptr(), oz.loc).as_ref().unwrap()[*incremental_path_start..] });
+
+                // println!("wz path {} {}", serialize(template_prefixes[subsumption[i]]), serialize(wz.path()));
+                // println!("insert path {}", serialize(&buffer[..oz.loc]));
+                any_new |= wz.remove_val(true).is_none();
+                wz.reset();
+            }
+            true
+        });
+
+        (touched, any_new)
+}
+
+
 impl DefaultSpace {
 
     pub fn transform_multi(&mut self, patterns: &[Expr], template: Expr) -> (usize, bool) {

--- a/kernel/src/space_temporary.rs
+++ b/kernel/src/space_temporary.rs
@@ -10,7 +10,7 @@ use mork_bytestring::{Expr, ExprTrait, OwnedExpr, ExprZipper};
 use pathmap::{PathMap, morphisms::Catamorphism, zipper::*};
 
 use crate::space::{
-    ExecError, dump_as_sexpr_impl, load_csv_impl, load_json_impl, load_sexpr_impl, transform_multi_multi_impl, metta_calculus_impl, token_bfs_impl, ParDataParser
+    ExecError, dump_as_sexpr_impl, load_csv_impl, load_json_impl, load_sexpr_impl, transform_multi_multi_impl, subtract_multi_multi_impl, metta_calculus_impl, token_bfs_impl, ParDataParser
 };
 
 #[cfg(feature="neo4j")]
@@ -348,6 +348,31 @@ pub trait Space: Sized {
         let mut template_wzs: Vec<_> = writers.iter_mut().map(|writer| self.write_zipper(writer)).collect();
 
         let result = transform_multi_multi_impl(patterns, &pattern_rzs, templates, template_prefixes, &mut template_wzs);
+
+        for wz in template_wzs {
+            self.cleanup_write_zipper(wz);
+        }
+        result
+    }
+
+    fn subtract_multi_multi<'s, E: ExprTrait>(
+        &'s self,
+        patterns : &[E],
+        read_map: &PathMap<()>,
+        templates : &[E],
+        template_prefixes : &[(usize, usize)],
+        writers : &mut [Self::Writer<'s>],
+    ) -> (usize, bool) {
+        let make_prefix = |e:&Expr|  unsafe { e.prefix().unwrap_or_else(|_| e.span()).as_ref().unwrap() };
+
+        let pattern_rzs: Vec<_> = patterns.iter().map(|pat| {
+            let path = make_prefix(&pat.borrow());
+            read_map.read_zipper_at_borrowed_path(path)
+        }).collect();
+
+        let mut template_wzs: Vec<_> = writers.iter_mut().map(|writer| self.write_zipper(writer)).collect();
+
+        let result = subtract_multi_multi_impl(patterns, &pattern_rzs, templates, template_prefixes, &mut template_wzs);
 
         for wz in template_wzs {
             self.cleanup_write_zipper(wz);

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -1326,6 +1326,59 @@ impl CommandDefinition for StopCmd {
 }
 
 // ===***===***===***===***===***===***===***===***===***===***===***===***===***===***===***
+// subtract
+// ===***===***===***===***===***===***===***===***===***===***===***===***===***===***===***
+
+/// expects the post body to be of this form of sexpr
+/// ```ignore
+/// (subtract
+///   (, (pattern0 ...)
+///      (pattern1 ...)
+///      ...
+///   )
+///   (, (template0 ...)
+///      (template1 ...)
+///      ...
+///   )
+/// )
+/// ```
+
+pub struct SubtractCmd;
+
+impl CommandDefinition for SubtractCmd {
+    const NAME: &'static str = "subtract";
+    const CONST_CMD: &'static Self = &Self;
+    const CONSUME_WORKER: bool = true;
+    fn args() -> &'static [ArgDef] {
+        &[]
+    }
+    fn properties() -> &'static [PropDef] {
+        &[]
+    }
+    async fn work(ctx: MorkService, cmd: Command, thread: Option<WorkThreadHandle>, mut _req: Request<IncomingBody>) -> Result<WorkResult, CommandError> {
+        let work_thread = thread.unwrap();
+
+        let post_bytes = get_all_post_frame_bytes(&mut _req).await?;
+        let src = core::str::from_utf8(&post_bytes).map_err(|e| CommandError::external(StatusCode::BAD_REQUEST, format!("{e:?}")))?;
+
+        let (patterns, templates) = pattern_template_args(&ctx.0.space, src)
+            .map_err(|e| CommandError::external(StatusCode::BAD_REQUEST, format!("{e:?}")))?;
+
+        let (read_map, template_prefixes, mut writers) = ctx.0.space.acquire_transform_permissions(&patterns, &templates, &())
+            .map_err(|exec_err| exec_err.into_perm_err().unwrap())?;
+
+        work_thread.dispatch_blocking_task(cmd, move |_c| {
+            ctx.0.space.subtract_multi_multi(&patterns, &read_map, &templates, &template_prefixes, &mut writers);
+            Ok(())
+        }).await;
+
+        Ok(WorkResult::Immediate(Bytes::from("ACK. Subtract dispatched")))
+    }
+}
+
+
+
+// ===***===***===***===***===***===***===***===***===***===***===***===***===***===***===***
 // transform
 // ===***===***===***===***===***===***===***===***===***===***===***===***===***===***===***
 
@@ -1433,7 +1486,8 @@ fn pattern_template_args(space: &ServerSpace, input: &str)->Result<(Vec<OwnedExp
     let Ok(Tag::Arity(3)) = expr_z.item() else { return  Err(TransformMultiMultiError::ExpectedArity3AsFirstByte);};
 
     expr_z.next_child();
-    if unsafe {expr_z.subexpr().span().as_ref() != mork::expr!(space, "transform").span().as_ref()} {
+    if unsafe {expr_z.subexpr().span().as_ref() != mork::expr!(space, "transform").span().as_ref() && 
+        expr_z.subexpr().span().as_ref() != mork::expr!(space, "subtract").span().as_ref() } {
         return Err(TransformMultiMultiError::ExpectedTransformSym)
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -593,6 +593,7 @@ impl Service<Request<IncomingBody>> for MorkService {
             | GET => MettaThreadCmd
             | GET => MettaThreadSuspendCmd
             | POST => TransformCmd
+            | POST => SubtractCmd
         }
     }
 }


### PR DESCRIPTION
This subtract command works identically to TransformMultiMulti, but instead of unifying, it removes the resulting atoms.